### PR TITLE
test(service): ampliar cobertura unitaria de TicketService (T-18)

### DIFF
--- a/src/test/java/com/ProyectoProcesosSoftware/service/TicketServiceTest.java
+++ b/src/test/java/com/ProyectoProcesosSoftware/service/TicketServiceTest.java
@@ -1,4 +1,4 @@
-package com.ProyectoProcesosSoftware;
+package com.ProyectoProcesosSoftware.service;
 
 import com.ProyectoProcesosSoftware.dto.TicketResponseDTO;
 import com.ProyectoProcesosSoftware.exception.BusinessRuleException;

--- a/src/test/java/com/ProyectoProcesosSoftware/service/TicketServiceTest.java
+++ b/src/test/java/com/ProyectoProcesosSoftware/service/TicketServiceTest.java
@@ -1,7 +1,8 @@
-package com.ProyectoProcesosSoftware.service;
+package com.ProyectoProcesosSoftware;
 
 import com.ProyectoProcesosSoftware.dto.TicketResponseDTO;
 import com.ProyectoProcesosSoftware.exception.BusinessRuleException;
+import com.ProyectoProcesosSoftware.exception.ResourceNotFoundException;
 import com.ProyectoProcesosSoftware.exception.UnauthorizedActionException;
 import com.ProyectoProcesosSoftware.model.*;
 import com.ProyectoProcesosSoftware.pricing.PricingContext;
@@ -10,8 +11,10 @@ import com.ProyectoProcesosSoftware.repository.TicketRepository;
 import com.ProyectoProcesosSoftware.repository.UsuarioRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,13 +22,27 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.lenient;
 
+/**
+ * T-18: Tests unitarios del servicio de compra de entradas.
+ *
+ * Cubre los escenarios exigidos por la tarea:
+ *  - Compra exitosa con estado VALIDO y precio correcto.
+ *  - Evento no existente (404 / ResourceNotFoundException).
+ *  - Evento no PUBLICADO (409 / BusinessRuleException).
+ *  - Usuario no ASISTENTE (403 / UnauthorizedActionException).
+ *  - Aforo completo (409 / BusinessRuleException).
+ *  - Compra que completa aforo -> estado AGOTADO.
+ *  - entradasVendidas se incrementa.
+ *  - Integración correcta con PricingContext (Strategy Pattern).
+ */
 @ExtendWith(MockitoExtension.class)
 class TicketServiceTest {
 
@@ -63,89 +80,281 @@ class TicketServiceTest {
         asistente.setRol(Rol.ASISTENTE);
     }
 
-    @Test
-    @DisplayName("Compra exitosa → devuelve TicketResponseDTO con precioFinal")
-    void comprar_exitoso() {
-        when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
-        when(usuarioRepository.findById(2L)).thenReturn(Optional.of(asistente));
-        when(ticketRepository.existsByEventoIdAndAsistenteId(1L, 2L)).thenReturn(false);
-        when(pricingContext.calcularPrecio(any(), anyInt(), anyInt()))
-                .thenReturn(new BigDecimal("50.00"));
-        when(pricingContext.nombreEstrategia(anyInt(), anyInt())).thenReturn("EarlyBird");
-        when(ticketRepository.save(any())).thenAnswer(inv -> {
-            Ticket t = inv.getArgument(0);
-            t.setId(10L);
+    // ---------------------------------------------------------------------
+    // comprarEntrada — casos de éxito
+    // ---------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("comprarEntrada — casos de éxito")
+    class CompraExitosa {
+
+        @Test
+        @DisplayName("Compra válida: devuelve DTO con precio final y nombre de estrategia")
+        void comprar_exitoso_devuelveDTO() {
+            stubCompraValida(new BigDecimal("50.00"), "EarlyBird");
+
+            TicketResponseDTO result = ticketService.comprarEntrada(1L, 2L);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getPrecioFinal()).isEqualByComparingTo("50.00");
+            assertThat(result.getEstrategiaPrecio()).isEqualTo("EarlyBird");
+            assertThat(result.getEventoId()).isEqualTo(1L);
+            assertThat(result.getEventoNombre()).isEqualTo("Concierto");
+            assertThat(result.getAsistenteId()).isEqualTo(2L);
+            assertThat(result.getAsistenteNombre()).isEqualTo("Juan");
+        }
+
+        @Test
+        @DisplayName("El ticket creado queda con estado VALIDO y el precio devuelto por la strategy")
+        void comprar_persisteTicketValidoConPrecioDeStrategy() {
+            BigDecimal precioStrategy = new BigDecimal("62.50");
+            stubCompraValida(precioStrategy, "Regular");
+
+            ticketService.comprarEntrada(1L, 2L);
+
+            ArgumentCaptor<Ticket> captor = ArgumentCaptor.forClass(Ticket.class);
+            verify(ticketRepository).save(captor.capture());
+            Ticket guardado = captor.getValue();
+
+            assertThat(guardado.getEstado()).isEqualTo(TicketStatus.VALIDO);
+            assertThat(guardado.getPrecioFinal()).isEqualByComparingTo(precioStrategy);
+            assertThat(guardado.getEvento()).isSameAs(evento);
+            assertThat(guardado.getAsistente()).isSameAs(asistente);
+        }
+
+        @Test
+        @DisplayName("entradasVendidas se incrementa en 1 y se persiste el evento")
+        void comprar_incrementaEntradasVendidas() {
+            stubCompraValida(new BigDecimal("50.00"), "EarlyBird");
+
+            ticketService.comprarEntrada(1L, 2L);
+
+            assertThat(evento.getEntradasVendidas()).isEqualTo(31);
+            verify(eventoRepository).save(evento);
+        }
+
+        @Test
+        @DisplayName("PricingContext recibe precioBase, entradasVendidas (antes de incrementar) y aforo")
+        void comprar_invocaStrategyConArgumentosCorrectos() {
+            stubCompraValida(new BigDecimal("50.00"), "EarlyBird");
+
+            ticketService.comprarEntrada(1L, 2L);
+
+            verify(pricingContext).calcularPrecio(
+                    new BigDecimal("50.00"), 30, 100);
+            verify(pricingContext).nombreEstrategia(30, 100);
+        }
+
+        @Test
+        @DisplayName("Compra que no completa el aforo deja el evento en PUBLICADO")
+        void comprar_noUltima_mantienePublicado() {
+            stubCompraValida(new BigDecimal("50.00"), "EarlyBird");
+
+            ticketService.comprarEntrada(1L, 2L);
+
+            assertThat(evento.getEstado()).isEqualTo(EstadoEvento.PUBLICADO);
+        }
+
+        @Test
+        @DisplayName("Compra que ocupa la última plaza pasa el evento a AGOTADO")
+        void comprar_ultimaPlaza_cambiaAgotado() {
+            evento.setEntradasVendidas(99);
+            stubCompraValida(new BigDecimal("75.00"), "LastMinute");
+
+            ticketService.comprarEntrada(1L, 2L);
+
+            assertThat(evento.getEntradasVendidas()).isEqualTo(100);
+            assertThat(evento.getEstado()).isEqualTo(EstadoEvento.AGOTADO);
+        }
+
+        private void stubCompraValida(BigDecimal precio, String estrategia) {
+            when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
+            when(usuarioRepository.findById(2L)).thenReturn(Optional.of(asistente));
+            when(ticketRepository.existsByEventoIdAndAsistenteId(1L, 2L)).thenReturn(false);
+            when(pricingContext.calcularPrecio(any(), anyInt(), anyInt())).thenReturn(precio);
+            when(pricingContext.nombreEstrategia(anyInt(), anyInt())).thenReturn(estrategia);
+            when(ticketRepository.save(any())).thenAnswer(inv -> {
+                Ticket t = inv.getArgument(0);
+                t.setId(10L);
+                return t;
+            });
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // comprarEntrada — errores
+    // ---------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("comprarEntrada — validaciones y errores")
+    class CompraErrores {
+
+        @Test
+        @DisplayName("Evento no existe -> ResourceNotFoundException (404)")
+        void comprar_eventoNoExistente_404() {
+            when(eventoRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> ticketService.comprarEntrada(999L, 2L))
+                    .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("Evento");
+
+            verify(ticketRepository, never()).save(any());
+            verify(eventoRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Evento en BORRADOR -> BusinessRuleException (409)")
+        void comprar_eventoNoPublicado_BORRADOR() {
+            evento.setEstado(EstadoEvento.BORRADOR);
+            when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
+
+            assertThatThrownBy(() -> ticketService.comprarEntrada(1L, 2L))
+                    .isInstanceOf(BusinessRuleException.class)
+                    .hasMessageContaining("publicados");
+
+            verify(ticketRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Evento en AGOTADO -> BusinessRuleException (no permite compra)")
+        void comprar_eventoEnAgotado() {
+            evento.setEstado(EstadoEvento.AGOTADO);
+            when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
+
+            assertThatThrownBy(() -> ticketService.comprarEntrada(1L, 2L))
+                    .isInstanceOf(BusinessRuleException.class);
+
+            verify(ticketRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Aforo completo -> BusinessRuleException (409)")
+        void comprar_aforoCompleto_409() {
+            evento.setEntradasVendidas(100);
+            when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
+
+            assertThatThrownBy(() -> ticketService.comprarEntrada(1L, 2L))
+                    .isInstanceOf(BusinessRuleException.class)
+                    .hasMessageContaining("plazas");
+
+            verify(usuarioRepository, never()).findById(any());
+            verify(ticketRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Usuario no existe -> ResourceNotFoundException (404)")
+        void comprar_usuarioNoExistente_404() {
+            when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
+            when(usuarioRepository.findById(2L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> ticketService.comprarEntrada(1L, 2L))
+                    .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("Usuario");
+
+            verify(ticketRepository, never()).save(any());
+            verify(eventoRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Usuario con rol ORGANIZADOR -> UnauthorizedActionException (403)")
+        void comprar_organizador_403() {
+            asistente.setRol(Rol.ORGANIZADOR);
+            when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
+            when(usuarioRepository.findById(2L)).thenReturn(Optional.of(asistente));
+
+            assertThatThrownBy(() -> ticketService.comprarEntrada(1L, 2L))
+                    .isInstanceOf(UnauthorizedActionException.class)
+                    .hasMessageContaining("asistentes");
+
+            verify(ticketRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Ya tiene una entrada para este evento -> BusinessRuleException")
+        void comprar_duplicado() {
+            when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
+            when(usuarioRepository.findById(2L)).thenReturn(Optional.of(asistente));
+            when(ticketRepository.existsByEventoIdAndAsistenteId(1L, 2L)).thenReturn(true);
+
+            assertThatThrownBy(() -> ticketService.comprarEntrada(1L, 2L))
+                    .isInstanceOf(BusinessRuleException.class)
+                    .hasMessageContaining("Ya tienes");
+
+            verify(ticketRepository, never()).save(any());
+            verify(eventoRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Si la validación falla, no se llama al PricingContext")
+        void comprar_errorValidacion_noInvocaStrategy() {
+            evento.setEstado(EstadoEvento.CANCELADO);
+            when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
+
+            assertThatThrownBy(() -> ticketService.comprarEntrada(1L, 2L))
+                    .isInstanceOf(BusinessRuleException.class);
+
+            verifyNoInteractions(pricingContext);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // misEntradas / getMisEntradas
+    // ---------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Consulta de entradas del usuario")
+    class Consulta {
+
+        @Test
+        @DisplayName("misEntradas devuelve los tickets del usuario mapeados a DTO")
+        void misEntradas_mapea() {
+            Ticket t = ticketMock(100L, new BigDecimal("50.00"));
+            when(ticketRepository.findByAsistenteId(2L)).thenReturn(List.of(t));
+            when(pricingContext.nombreEstrategia(anyInt(), anyInt())).thenReturn("EarlyBird");
+
+            List<TicketResponseDTO> out = ticketService.misEntradas(2L);
+
+            assertThat(out).hasSize(1);
+            assertThat(out.get(0).getId()).isEqualTo(100L);
+            assertThat(out.get(0).getEstrategiaPrecio()).isEqualTo("EarlyBird");
+            verify(pricingContext, never()).calcularPrecio(any(), anyInt(), anyInt());
+        }
+
+        @Test
+        @DisplayName("misEntradas con usuario sin tickets devuelve lista vacía")
+        void misEntradas_listaVacia() {
+            when(ticketRepository.findByAsistenteId(2L)).thenReturn(Collections.emptyList());
+
+            List<TicketResponseDTO> out = ticketService.misEntradas(2L);
+
+            assertThat(out).isEmpty();
+            verifyNoInteractions(pricingContext);
+        }
+
+        @Test
+        @DisplayName("getMisEntradas usa findByAsistenteIdOrderByFechaCompraDesc")
+        void getMisEntradas_ordenDesc() {
+            Ticket t = ticketMock(200L, new BigDecimal("75.00"));
+            when(ticketRepository.findByAsistenteIdOrderByFechaCompraDesc(2L))
+                    .thenReturn(List.of(t));
+            when(pricingContext.nombreEstrategia(anyInt(), anyInt())).thenReturn("Regular");
+
+            List<TicketResponseDTO> out = ticketService.getMisEntradas(2L);
+
+            assertThat(out).hasSize(1);
+            assertThat(out.get(0).getId()).isEqualTo(200L);
+            assertThat(out.get(0).getEstrategiaPrecio()).isEqualTo("Regular");
+            verify(ticketRepository).findByAsistenteIdOrderByFechaCompraDesc(2L);
+        }
+
+        private Ticket ticketMock(Long id, BigDecimal precio) {
+            Ticket t = new Ticket();
+            t.setId(id);
+            t.setEvento(evento);
+            t.setAsistente(asistente);
+            t.setPrecioFinal(precio);
+            t.setEstado(TicketStatus.VALIDO);
             return t;
-        });
-
-        TicketResponseDTO result = ticketService.comprarEntrada(1L, 2L);
-
-        assertThat(result.getPrecioFinal()).isEqualByComparingTo("50.00");
-        assertThat(result.getEstrategiaPrecio()).isEqualTo("EarlyBird");
-        verify(ticketRepository).save(any());
-        verify(eventoRepository).save(evento);
-    }
-
-    @Test
-    @DisplayName("Evento agotado → lanza BusinessRuleException")
-    void comprar_eventoAgotado() {
-        evento.setEntradasVendidas(100);
-        when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
-
-        assertThatThrownBy(() -> ticketService.comprarEntrada(1L, 2L))
-                .isInstanceOf(BusinessRuleException.class)
-                .hasMessageContaining("plazas");
-    }
-
-    @Test
-    @DisplayName("Evento no publicado → lanza BusinessRuleException")
-    void comprar_eventoNoPub() {
-        evento.setEstado(EstadoEvento.BORRADOR);
-        when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
-
-        assertThatThrownBy(() -> ticketService.comprarEntrada(1L, 2L))
-                .isInstanceOf(BusinessRuleException.class)
-                .hasMessageContaining("publicados");
-    }
-
-    @Test
-    @DisplayName("Organizador intenta comprar → lanza UnauthorizedActionException")
-    void comprar_organizador_403() {
-        asistente.setRol(Rol.ORGANIZADOR);
-        when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
-        when(usuarioRepository.findById(2L)).thenReturn(Optional.of(asistente));
-        lenient().when(ticketRepository.existsByEventoIdAndAsistenteId(1L, 2L)).thenReturn(false); // ← lenient()
-
-        assertThatThrownBy(() -> ticketService.comprarEntrada(1L, 2L))
-            .isInstanceOf(UnauthorizedActionException.class);
-    }
-
-    @Test
-    @DisplayName("Ya tiene entrada → lanza BusinessRuleException")
-    void comprar_duplicado() {
-        when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
-        when(usuarioRepository.findById(2L)).thenReturn(Optional.of(asistente));
-        when(ticketRepository.existsByEventoIdAndAsistenteId(1L, 2L)).thenReturn(true);
-
-        assertThatThrownBy(() -> ticketService.comprarEntrada(1L, 2L))
-                .isInstanceOf(BusinessRuleException.class)
-                .hasMessageContaining("Ya tienes");
-    }
-
-    @Test
-    @DisplayName("Última plaza → estado cambia a AGOTADO")
-    void comprar_ultimaPlaza_agotado() {
-        evento.setEntradasVendidas(99);
-        when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
-        when(usuarioRepository.findById(2L)).thenReturn(Optional.of(asistente));
-        when(ticketRepository.existsByEventoIdAndAsistenteId(1L, 2L)).thenReturn(false);
-        when(pricingContext.calcularPrecio(any(), anyInt(), anyInt()))
-                .thenReturn(new BigDecimal("75.00"));
-        when(pricingContext.nombreEstrategia(anyInt(), anyInt())).thenReturn("LastMinute");
-        when(ticketRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
-
-        ticketService.comprarEntrada(1L, 2L);
-
-        assertThat(evento.getEstado()).isEqualTo(EstadoEvento.AGOTADO);
+        }
     }
 }


### PR DESCRIPTION
**Descripción:** Tests unitarios para TicketService cubriendo compra exitosa, validaciones y control de aforo.

**Subtareas:**

- Test: compra exitosa → crea ticket con estado VÁLIDA y precio correcto
- Test: compra con evento no existente → lanza excepción 404
- Test: compra con evento no PUBLICADO → lanza excepción 409
- Test: compra con usuario no ASISTENTE → lanza excepción 403
- Test: compra cuando aforo completo → lanza excepción 409
- Test: compra que completa aforo → estado del evento cambia a AGOTADO
- Test: entradasVendidas se incrementa correctamente tras compra
- Usar Mockito para mockear repositorios