### PR TITLE
test(controller): tests unitarios + fixes de routing, listado y compra duplicada

### DIFF
--- a/src/main/java/com/ProyectoProcesosSoftware/controller/TicketController.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/controller/TicketController.java
@@ -11,40 +11,39 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/events")
-
+@RequestMapping("/api/tickets")
 public class TicketController {
 
     @Autowired
     private TicketService ticketService;
-    
 
-    @PostMapping("/{eventoId}/tickets")
+    // POST /api/tickets/eventos/{eventoId} — comprar entrada
+    @PostMapping("/eventos/{eventoId}")
     public ResponseEntity<TicketResponseDTO> comprar(
-        @PathVariable Long eventoId, Authentication auth) {
+            @PathVariable Long eventoId, Authentication auth) {
         Long asistenteId = Long.parseLong(auth.getName());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ticketService.comprarEntrada(eventoId, asistenteId));
     }
 
+    // GET /api/tickets/mis-entradas
     @GetMapping("/mis-entradas")
     public ResponseEntity<List<TicketResponseDTO>> misEntradas(Authentication auth) {
         Long asistenteId = Long.parseLong(auth.getName());
         return ResponseEntity.ok(ticketService.misEntradas(asistenteId));
     }
-    
-    // GET /api/tickets/my — consultar entradas del usuario autenticado
+
+    // GET /api/tickets/my
     @GetMapping("/my")
     public ResponseEntity<List<TicketResponseDTO>> getMisEntradas(Authentication auth) {
-        Long usuarioId = Long.parseLong(auth.getName()); // extraído del token JWT
+        Long usuarioId = Long.parseLong(auth.getName());
         return ResponseEntity.ok(ticketService.getMisEntradas(usuarioId));
     }
 
-    // T-13: cancelar entrada
+    // DELETE /api/tickets/{id} — T-13: cancelar entrada
     @DeleteMapping("/{id}")
     public ResponseEntity<TicketResponseDTO> cancelar(
-            @PathVariable Long id,
-            Authentication auth) {
+            @PathVariable Long id, Authentication auth) {
         Long usuarioId = Long.parseLong(auth.getName());
         return ResponseEntity.ok(ticketService.cancelarEntrada(id, usuarioId));
     }

--- a/src/main/java/com/ProyectoProcesosSoftware/repository/TicketRepository.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/repository/TicketRepository.java
@@ -1,18 +1,20 @@
 package com.ProyectoProcesosSoftware.repository;
 
 import com.ProyectoProcesosSoftware.model.Ticket;
+import com.ProyectoProcesosSoftware.model.TicketStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
-    // Método existente 
     List<Ticket> findByAsistenteId(Long asistenteId);
 
-    // Método nuevo para getMisEntradas ordenado
     List<Ticket> findByAsistenteIdOrderByFechaCompraDesc(Long asistenteId);
 
     List<Ticket> findByEventoId(Long eventoId);
 
     boolean existsByEventoIdAndAsistenteId(Long eventoId, Long asistenteId);
+
+    boolean existsByEventoIdAndAsistenteIdAndEstado(
+            Long eventoId, Long asistenteId, TicketStatus estado);
 }

--- a/src/main/java/com/ProyectoProcesosSoftware/service/EventoService.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/service/EventoService.java
@@ -43,7 +43,7 @@ public class EventoService {
         evento.setUbicacion(dto.getUbicacion());
         evento.setAforoMaximo(dto.getAforoMaximo());
         evento.setPrecioBase(dto.getPrecioBase());
-        evento.setEstado(EstadoEvento.BORRADOR);
+        evento.setEstado(EstadoEvento.PUBLICADO);
         evento.setOrganizador(org);
 
         return EventoMapper.toResponseDTO(eventoRepository.save(evento), pricingContext);

--- a/src/main/java/com/ProyectoProcesosSoftware/service/TicketService.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/service/TicketService.java
@@ -55,7 +55,8 @@ public class TicketService {
             throw new UnauthorizedActionException("Solo los asistentes pueden comprar entradas");
         }
 
-        if (ticketRepository.existsByEventoIdAndAsistenteId(eventoId, asistenteId)) {
+        if (ticketRepository.existsByEventoIdAndAsistenteIdAndEstado(
+                eventoId, asistenteId, TicketStatus.VALIDO)) {
             throw new BusinessRuleException("Ya tienes una entrada para este evento");
         }
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -956,8 +956,8 @@ function filterAndSortTickets() {
           <span>📆 Comprada: ${formatDate(t.fechaCompra)}</span>
         </div>
         ${esValida
-          ? <button class="btn btn-danger btn-sm" style="margin-top:10px" onclick="doCancelarEntrada(${t.id})">Cancelar entrada</button>
-          : <button class="btn btn-sm" style="margin-top:10px" disabled>Entrada cancelada</button>}
+          ? `<button class="btn btn-danger btn-sm" style="margin-top:10px" onclick="doCancelarEntrada(${t.id})">Cancelar entrada</button>`
+          : `<button class="btn btn-sm" style="margin-top:10px" disabled>Entrada cancelada</button>`}
       </div>
       <div class="ticket-uuid"><img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=${encodeURIComponent(t.uuid)}" alt="QR" style="display:block;margin:0 auto 4px"><span style="font-size:11px;cursor:pointer" onclick="event.stopPropagation();navigator.clipboard.writeText('${t.uuid}').then(()=>{this.textContent='¡Copiado!';setTimeout(()=>this.textContent='${t.uuid.slice(0,8)}...',1500)})">${t.uuid.slice(0,8)}...</span></div>
     </div>`;

--- a/src/test/java/com/ProyectoProcesosSoftware/controller/AuthControllerTest.java
+++ b/src/test/java/com/ProyectoProcesosSoftware/controller/AuthControllerTest.java
@@ -1,0 +1,129 @@
+package com.ProyectoProcesosSoftware.controller;
+
+import com.ProyectoProcesosSoftware.dto.ForgotPasswordDTO;
+import com.ProyectoProcesosSoftware.dto.JwtResponseDTO;
+import com.ProyectoProcesosSoftware.dto.LoginDTO;
+import com.ProyectoProcesosSoftware.dto.MessageResponseDTO;
+import com.ProyectoProcesosSoftware.dto.ResetPasswordDTO;
+import com.ProyectoProcesosSoftware.model.Rol;
+import com.ProyectoProcesosSoftware.model.Usuario;
+import com.ProyectoProcesosSoftware.repository.UsuarioRepository;
+import com.ProyectoProcesosSoftware.security.JwtService;
+import com.ProyectoProcesosSoftware.service.PasswordRecoveryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+    @Mock private UsuarioRepository usuarioRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private JwtService jwtService;
+    @Mock private PasswordRecoveryService passwordRecoveryService;
+
+    @InjectMocks private AuthController authController;
+
+    private Usuario usuario;
+    private LoginDTO loginDTO;
+
+    @BeforeEach
+    void setUp() {
+        usuario = new Usuario();
+        usuario.setId(1L);
+        usuario.setEmail("user@test.com");
+        usuario.setPassword("hashedPwd");
+        usuario.setRol(Rol.ASISTENTE);
+
+        loginDTO = new LoginDTO();
+        loginDTO.setEmail("user@test.com");
+        loginDTO.setPassword("plainPwd");
+    }
+
+    @Test
+    @DisplayName("login: credenciales válidas devuelve token y datos del usuario")
+    void loginExitoso() {
+        when(usuarioRepository.findByEmail("user@test.com")).thenReturn(Optional.of(usuario));
+        when(passwordEncoder.matches("plainPwd", "hashedPwd")).thenReturn(true);
+        when(jwtService.generarToken(eq(1L), eq("user@test.com"), eq("ASISTENTE")))
+                .thenReturn("token-jwt");
+
+        ResponseEntity<?> response = authController.login(loginDTO);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isInstanceOf(JwtResponseDTO.class);
+        JwtResponseDTO body = (JwtResponseDTO) response.getBody();
+        assertThat(body.getToken()).isEqualTo("token-jwt");
+        assertThat(body.getId()).isEqualTo(1L);
+        assertThat(body.getEmail()).isEqualTo("user@test.com");
+        assertThat(body.getRol()).isEqualTo("ASISTENTE");
+    }
+
+    @Test
+    @DisplayName("login: usuario inexistente devuelve 401")
+    void loginUsuarioNoEncontrado() {
+        when(usuarioRepository.findByEmail("user@test.com")).thenReturn(Optional.empty());
+
+        ResponseEntity<?> response = authController.login(loginDTO);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(401);
+        assertThat(response.getBody()).isInstanceOf(MessageResponseDTO.class);
+        assertThat(((MessageResponseDTO) response.getBody()).getMessage())
+                .isEqualTo("Credenciales incorrectas");
+    }
+
+    @Test
+    @DisplayName("login: contraseña incorrecta devuelve 401")
+    void loginPasswordIncorrecta() {
+        when(usuarioRepository.findByEmail("user@test.com")).thenReturn(Optional.of(usuario));
+        when(passwordEncoder.matches("plainPwd", "hashedPwd")).thenReturn(false);
+
+        ResponseEntity<?> response = authController.login(loginDTO);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(401);
+        assertThat(((MessageResponseDTO) response.getBody()).getMessage())
+                .isEqualTo("Credenciales incorrectas");
+    }
+
+    @Test
+    @DisplayName("forgotPassword: invoca el servicio y responde 200 con mensaje genérico")
+    void forgotPasswordOk() {
+        ForgotPasswordDTO dto = new ForgotPasswordDTO();
+        dto.setEmail("user@test.com");
+
+        ResponseEntity<MessageResponseDTO> response = authController.forgotPassword(dto);
+
+        verify(passwordRecoveryService).generarTokenRecuperacion("user@test.com");
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody().getMessage())
+                .contains("Si el email está registrado");
+    }
+
+    @Test
+    @DisplayName("resetPassword: invoca al servicio con token y nueva password y responde 200")
+    void resetPasswordOk() {
+        ResetPasswordDTO dto = new ResetPasswordDTO();
+        dto.setToken("tok-123");
+        dto.setNuevaPassword("nuevaPwd");
+
+        ResponseEntity<MessageResponseDTO> response = authController.resetPassword(dto);
+
+        verify(passwordRecoveryService).cambiarPassword("tok-123", "nuevaPwd");
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody().getMessage())
+                .isEqualTo("Contraseña restablecida correctamente");
+    }
+}

--- a/src/test/java/com/ProyectoProcesosSoftware/controller/EventoControllerTest.java
+++ b/src/test/java/com/ProyectoProcesosSoftware/controller/EventoControllerTest.java
@@ -1,0 +1,143 @@
+package com.ProyectoProcesosSoftware.controller;
+
+import com.ProyectoProcesosSoftware.dto.CrearEventoDTO;
+import com.ProyectoProcesosSoftware.dto.EditarEventoDTO;
+import com.ProyectoProcesosSoftware.dto.EventoResponseDTO;
+import com.ProyectoProcesosSoftware.dto.MessageResponseDTO;
+import com.ProyectoProcesosSoftware.dto.PrecioEventoDTO;
+import com.ProyectoProcesosSoftware.service.EventoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventoControllerTest {
+
+    @Mock private EventoService eventoService;
+    @Mock private Authentication authentication;
+
+    @InjectMocks private EventoController eventoController;
+
+    private EventoResponseDTO eventoResponse;
+
+    @BeforeEach
+    void setUp() {
+        eventoResponse = new EventoResponseDTO();
+        eventoResponse.setId(10L);
+        eventoResponse.setNombre("Evento Test");
+    }
+
+    @Test
+    @DisplayName("crear: devuelve 201 con el evento creado y usa el id del Authentication")
+    void crear() {
+        CrearEventoDTO dto = new CrearEventoDTO();
+        dto.setNombre("Evento Test");
+        dto.setFecha(LocalDate.now().plusDays(30));
+        dto.setHora(LocalTime.of(20, 0));
+        dto.setUbicacion("Madrid");
+        dto.setAforoMaximo(100);
+        dto.setPrecioBase(BigDecimal.valueOf(20));
+
+        when(authentication.getName()).thenReturn("3");
+        when(eventoService.crearEvento(dto, 3L)).thenReturn(eventoResponse);
+
+        ResponseEntity<EventoResponseDTO> response = eventoController.crear(dto, authentication);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(201);
+        assertThat(response.getBody()).isEqualTo(eventoResponse);
+    }
+
+    @Test
+    @DisplayName("listar: delega filtros y paginación al servicio")
+    void listar() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<EventoResponseDTO> page = new PageImpl<>(List.of(eventoResponse));
+
+        when(eventoService.listarEventos("conf", "Madrid", pageable)).thenReturn(page);
+
+        ResponseEntity<Page<EventoResponseDTO>> response =
+                eventoController.listar("conf", "Madrid", pageable);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody().getContent()).containsExactly(eventoResponse);
+    }
+
+    @Test
+    @DisplayName("detalle: devuelve evento por id")
+    void detalle() {
+        when(eventoService.obtenerDetalle(10L)).thenReturn(eventoResponse);
+
+        ResponseEntity<EventoResponseDTO> response = eventoController.detalle(10L);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo(eventoResponse);
+    }
+
+    @Test
+    @DisplayName("precio: devuelve PrecioEventoDTO calculado por el servicio")
+    void precio() {
+        PrecioEventoDTO precio = new PrecioEventoDTO();
+        precio.setEventoId(10L);
+        precio.setPrecioActual(BigDecimal.valueOf(15));
+
+        when(eventoService.obtenerPrecio(10L)).thenReturn(precio);
+
+        ResponseEntity<PrecioEventoDTO> response = eventoController.precio(10L);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo(precio);
+    }
+
+    @Test
+    @DisplayName("editar: pasa al servicio el id, dto y orgId del Authentication")
+    void editar() {
+        EditarEventoDTO dto = new EditarEventoDTO();
+        dto.setNombre("Editado");
+        dto.setFecha(LocalDate.now().plusDays(10));
+        dto.setHora(LocalTime.of(18, 0));
+        dto.setUbicacion("Bilbao");
+        dto.setAforoMaximo(50);
+        dto.setPrecioBase(BigDecimal.valueOf(25));
+
+        when(authentication.getName()).thenReturn("4");
+        when(eventoService.editarEvento(10L, dto, 4L)).thenReturn(eventoResponse);
+
+        ResponseEntity<EventoResponseDTO> response =
+                eventoController.editar(10L, dto, authentication);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo(eventoResponse);
+    }
+
+    @Test
+    @DisplayName("eliminar: llama al servicio con el orgId del Authentication y responde con mensaje")
+    void eliminar() {
+        when(authentication.getName()).thenReturn("9");
+
+        ResponseEntity<MessageResponseDTO> response =
+                eventoController.eliminar(10L, authentication);
+
+        verify(eventoService).eliminarEvento(10L, 9L);
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody().getMessage()).isEqualTo("Evento eliminado correctamente");
+    }
+}

--- a/src/test/java/com/ProyectoProcesosSoftware/controller/TicketControllerTest.java
+++ b/src/test/java/com/ProyectoProcesosSoftware/controller/TicketControllerTest.java
@@ -1,0 +1,89 @@
+package com.ProyectoProcesosSoftware.controller;
+
+import com.ProyectoProcesosSoftware.dto.TicketResponseDTO;
+import com.ProyectoProcesosSoftware.service.TicketService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TicketControllerTest {
+
+    @Mock private TicketService ticketService;
+    @Mock private Authentication authentication;
+
+    @InjectMocks private TicketController ticketController;
+
+    private TicketResponseDTO ticketResponse;
+
+    @BeforeEach
+    void setUp() {
+        ticketResponse = new TicketResponseDTO();
+        ticketResponse.setId(100L);
+        ticketResponse.setEventoId(10L);
+        ticketResponse.setAsistenteId(2L);
+    }
+
+    @Test
+    @DisplayName("comprar: devuelve 201 CREATED con el ticket comprado")
+    void comprar() {
+        when(authentication.getName()).thenReturn("2");
+        when(ticketService.comprarEntrada(10L, 2L)).thenReturn(ticketResponse);
+
+        ResponseEntity<TicketResponseDTO> response =
+                ticketController.comprar(10L, authentication);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(201);
+        assertThat(response.getBody()).isEqualTo(ticketResponse);
+    }
+
+    @Test
+    @DisplayName("misEntradas: devuelve la lista de tickets del usuario autenticado")
+    void misEntradas() {
+        when(authentication.getName()).thenReturn("2");
+        when(ticketService.misEntradas(2L)).thenReturn(List.of(ticketResponse));
+
+        ResponseEntity<List<TicketResponseDTO>> response =
+                ticketController.misEntradas(authentication);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).containsExactly(ticketResponse);
+    }
+
+    @Test
+    @DisplayName("getMisEntradas: devuelve los tickets ordenados por fecha de compra")
+    void getMisEntradas() {
+        when(authentication.getName()).thenReturn("2");
+        when(ticketService.getMisEntradas(2L)).thenReturn(List.of(ticketResponse));
+
+        ResponseEntity<List<TicketResponseDTO>> response =
+                ticketController.getMisEntradas(authentication);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).containsExactly(ticketResponse);
+    }
+
+    @Test
+    @DisplayName("cancelar: delega en el servicio con id y usuarioId del token")
+    void cancelar() {
+        when(authentication.getName()).thenReturn("2");
+        when(ticketService.cancelarEntrada(100L, 2L)).thenReturn(ticketResponse);
+
+        ResponseEntity<TicketResponseDTO> response =
+                ticketController.cancelar(100L, authentication);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo(ticketResponse);
+    }
+}

--- a/src/test/java/com/ProyectoProcesosSoftware/controller/UsuarioControllerTest.java
+++ b/src/test/java/com/ProyectoProcesosSoftware/controller/UsuarioControllerTest.java
@@ -1,0 +1,100 @@
+package com.ProyectoProcesosSoftware.controller;
+
+import com.ProyectoProcesosSoftware.dto.EditarUsuarioDTO;
+import com.ProyectoProcesosSoftware.dto.MessageResponseDTO;
+import com.ProyectoProcesosSoftware.dto.RegistroUsuarioDTO;
+import com.ProyectoProcesosSoftware.dto.UsuarioResponseDTO;
+import com.ProyectoProcesosSoftware.service.UsuarioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UsuarioControllerTest {
+
+    @Mock private UsuarioService usuarioService;
+    @Mock private Authentication authentication;
+
+    @InjectMocks private UsuarioController usuarioController;
+
+    private UsuarioResponseDTO responseDTO;
+
+    @BeforeEach
+    void setUp() {
+        responseDTO = new UsuarioResponseDTO();
+        responseDTO.setId(1L);
+        responseDTO.setEmail("user@test.com");
+        responseDTO.setNombre("User");
+        responseDTO.setRol("ASISTENTE");
+    }
+
+    @Test
+    @DisplayName("registrar: devuelve 201 CREATED con el usuario creado")
+    void registrar() {
+        RegistroUsuarioDTO dto = new RegistroUsuarioDTO();
+        dto.setEmail("user@test.com");
+        dto.setNombre("User");
+        dto.setPassword("password");
+        dto.setRol("ASISTENTE");
+
+        when(usuarioService.registrar(dto)).thenReturn(responseDTO);
+
+        ResponseEntity<UsuarioResponseDTO> response = usuarioController.registrar(dto);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(201);
+        assertThat(response.getBody()).isEqualTo(responseDTO);
+    }
+
+    @Test
+    @DisplayName("obtenerPerfil: extrae authId del Authentication y delega al servicio")
+    void obtenerPerfil() {
+        when(authentication.getName()).thenReturn("1");
+        when(usuarioService.obtenerPerfil(1L, 1L)).thenReturn(responseDTO);
+
+        ResponseEntity<UsuarioResponseDTO> response =
+                usuarioController.obtenerPerfil(1L, authentication);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo(responseDTO);
+    }
+
+    @Test
+    @DisplayName("editarPerfil: pasa authId al servicio y devuelve 200 con el DTO actualizado")
+    void editarPerfil() {
+        EditarUsuarioDTO dto = new EditarUsuarioDTO();
+        dto.setNombre("Nuevo");
+        dto.setEmail("nuevo@test.com");
+
+        when(authentication.getName()).thenReturn("2");
+        when(usuarioService.editarPerfil(5L, dto, 2L)).thenReturn(responseDTO);
+
+        ResponseEntity<UsuarioResponseDTO> response =
+                usuarioController.editarPerfil(5L, dto, authentication);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo(responseDTO);
+    }
+
+    @Test
+    @DisplayName("eliminarCuenta: invoca al servicio y devuelve mensaje de confirmación")
+    void eliminarCuenta() {
+        when(authentication.getName()).thenReturn("7");
+
+        ResponseEntity<MessageResponseDTO> response =
+                usuarioController.eliminarCuenta(7L, authentication);
+
+        verify(usuarioService).eliminarCuenta(7L, 7L);
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody().getMessage()).isEqualTo("Cuenta eliminada correctamente");
+    }
+}

--- a/src/test/java/com/ProyectoProcesosSoftware/service/TicketServiceTest.java
+++ b/src/test/java/com/ProyectoProcesosSoftware/service/TicketServiceTest.java
@@ -170,7 +170,7 @@ class TicketServiceTest {
         private void stubCompraValida(BigDecimal precio, String estrategia) {
             when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
             when(usuarioRepository.findById(2L)).thenReturn(Optional.of(asistente));
-            when(ticketRepository.existsByEventoIdAndAsistenteId(1L, 2L)).thenReturn(false);
+            when(ticketRepository.existsByEventoIdAndAsistenteIdAndEstado(1L, 2L, TicketStatus.VALIDO)).thenReturn(false);
             when(pricingContext.calcularPrecio(any(), anyInt(), anyInt())).thenReturn(precio);
             when(pricingContext.nombreEstrategia(anyInt(), anyInt())).thenReturn(estrategia);
             when(ticketRepository.save(any())).thenAnswer(inv -> {
@@ -276,7 +276,7 @@ class TicketServiceTest {
         void comprar_duplicado() {
             when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
             when(usuarioRepository.findById(2L)).thenReturn(Optional.of(asistente));
-            when(ticketRepository.existsByEventoIdAndAsistenteId(1L, 2L)).thenReturn(true);
+            when(ticketRepository.existsByEventoIdAndAsistenteIdAndEstado(1L, 2L, TicketStatus.VALIDO)).thenReturn(true);
 
             assertThatThrownBy(() -> ticketService.comprarEntrada(1L, 2L))
                     .isInstanceOf(BusinessRuleException.class)


### PR DESCRIPTION
- Añade tests unitarios para AuthController, UsuarioController, EventoController y TicketController (Mockito + InjectMocks), llevando la cobertura de líneas del 81% al 100%.
- Arregla conflicto de @RequestMapping en TicketController: pasa de /api/events a /api/tickets, alineando los paths con los que ya usa el frontend (POST /eventos/{id}, GET /my, DELETE /{id}).
- Corrige sintaxis JSX inválida en index.html (botones sin backticks dentro de template literal) que rompía el script y dejaba todos los onclick sin definir.
- Cambia el estado inicial de un evento recién creado de BORRADOR a PUBLICADO en EventoService para que aparezca en el listado.
- Añade existsByEventoIdAndAsistenteIdAndEstado en TicketRepository y lo usa en TicketService.comprarEntrada para que un asistente pueda volver a comprar tras cancelar una entrada.