### PR TITLE
feat(US-18): añadir @Version a Evento para bloqueo optimista

### DIFF
--- a/src/main/java/com/ProyectoProcesosSoftware/model/Evento.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/model/Evento.java
@@ -17,6 +17,10 @@ public class Evento {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // US-18: bloqueo optimista para evitar sobreventa por concurrencia.
+    @Version
+    private Long version;
+
     @NotBlank(message = "El nombre es obligatorio")
     private String nombre;
 


### PR DESCRIPTION
## Resumen

Añade el campo `@Version Long version` a la entidad `Evento`. Hibernate
generará automáticamente una columna `version` y la incrementará en cada
`UPDATE`, lo que sienta la base para detectar colisiones concurrentes en
la compra de entradas (US-18).

## Tarea cubierta

- [x] T-18.1 · Añadir `@Version` a la entidad `Evento`

## Archivos modificados

- `src/main/java/com/ProyectoProcesosSoftware/model/Evento.java`

## Verificación

```bash
./gradlew test