### PR TITLE
T-20.3 · Validación cruzada en editarEvento: fecha pasada solo si FINALIZADO

### DIFF
--- a/src/main/java/com/ProyectoProcesosSoftware/service/EventoService.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/service/EventoService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDate;
 
 // ═══════════════════════════════════════════════════════════════
 // T-16 (Persona 4): Servicio de Eventos
@@ -72,6 +73,14 @@ public class EventoService {
         }
         if (dto.getAforoMaximo() < evento.getEntradasVendidas()) {
             throw new BusinessRuleException("No se puede reducir el aforo por debajo de las entradas vendidas");
+        }
+
+        // US-20 / T-20.3: solo se permite asignar una fecha pasada cuando el
+        // evento ya está FINALIZADO (caso de corrección histórica).
+        if (dto.getFecha().isBefore(LocalDate.now())
+                && evento.getEstado() != EstadoEvento.FINALIZADO) {
+            throw new BusinessRuleException(
+                    "Solo se puede asignar una fecha pasada a un evento ya FINALIZADO");
         }
 
         evento.setNombre(dto.getNombre());

--- a/src/test/java/com/ProyectoProcesosSoftware/service/EventoServiceTest.java
+++ b/src/test/java/com/ProyectoProcesosSoftware/service/EventoServiceTest.java
@@ -65,7 +65,7 @@ class EventoServiceTest {
 
         editarDTO = new EditarEventoDTO();
         editarDTO.setNombre("Editado");
-        editarDTO.setFecha(LocalDate.of(2025,6,20));
+        editarDTO.setFecha(LocalDate.now().plusMonths(2));
         editarDTO.setHora(LocalTime.of(21,0));
         editarDTO.setUbicacion("VIP");
         editarDTO.setAforoMaximo(600);
@@ -116,6 +116,31 @@ class EventoServiceTest {
         when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
         assertThatThrownBy(() -> eventoService.editarEvento(1L, editarDTO, 1L))
                 .isInstanceOf(BusinessRuleException.class);
+    }
+
+    // US-20 / T-20.3: la fecha pasada solo se acepta si el evento está FINALIZADO.
+    @Test
+    @DisplayName("Editar fecha pasada en evento PUBLICADO → BusinessRuleException (409)")
+    void editar_fechaPasada_publicado_409() {
+        editarDTO.setFecha(LocalDate.now().minusDays(5));
+        when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
+
+        assertThatThrownBy(() -> eventoService.editarEvento(1L, editarDTO, 1L))
+                .isInstanceOf(BusinessRuleException.class)
+                .hasMessageContaining("FINALIZADO");
+    }
+
+    @Test
+    @DisplayName("Editar fecha pasada en evento FINALIZADO → exitoso (caso de corrección)")
+    void editar_fechaPasada_finalizado_ok() {
+        evento.setEstado(EstadoEvento.FINALIZADO);
+        editarDTO.setFecha(LocalDate.now().minusDays(5));
+        when(eventoRepository.findById(1L)).thenReturn(Optional.of(evento));
+        when(eventoRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        EventoResponseDTO r = eventoService.editarEvento(1L, editarDTO, 1L);
+
+        assertThat(r.getNombre()).isEqualTo("Editado");
     }
 
     @Test void eliminar_sinVentas() {


### PR DESCRIPTION
## Resumen

Añade en `EventoService.editarEvento` la validación cruzada: si la nueva fecha es anterior a hoy y el estado actual del evento NO es `FINALIZADO`, lanza `BusinessRuleException` → 409. Permite el caso de corrección histórica sobre eventos ya finalizados (por ejemplo, ajustar la fecha real tras la celebración).

La validación va en el servicio en vez de en el DTO porque depende del estado actual del evento, que el DTO desconoce.

## Tarea cubierta

- [x] T-20.3 · Validación cruzada en `EditarEventoDTO`: fecha pasada solo si FINALIZADO

## Archivos modificados

- `src/main/java/com/ProyectoProcesosSoftware/service/EventoService.java`
- `src/test/java/com/ProyectoProcesosSoftware/service/EventoServiceTest.java`

## Verificación

```bash
./gradlew test jacocoTestCoverageVerification