### PR TITLE
feat(US-20): T-20.2 · Devolver mapa de errores por campo en errores 400

### DIFF
--- a/src/main/java/com/ProyectoProcesosSoftware/dto/ValidationErrorResponseDTO.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/dto/ValidationErrorResponseDTO.java
@@ -1,0 +1,20 @@
+package com.ProyectoProcesosSoftware.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+/**
+ * US-20: respuesta estructurada para errores 400 de validación.
+ * El campo {@code errors} mapea el nombre de cada campo inválido al mensaje
+ * concreto que ha producido la anotación, para que el cliente pueda mostrarlo
+ * junto al input correspondiente.
+ */
+@Data
+public class ValidationErrorResponseDTO {
+    private LocalDateTime timestamp;
+    private int status;
+    private String message;
+    private Map<String, String> errors;
+}

--- a/src/main/java/com/ProyectoProcesosSoftware/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.ProyectoProcesosSoftware.exception;
 
 import com.ProyectoProcesosSoftware.dto.ErrorResponseDTO;
+import com.ProyectoProcesosSoftware.dto.ValidationErrorResponseDTO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -9,7 +10,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.LocalDateTime;
-import java.util.stream.Collectors;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -34,19 +36,28 @@ public class GlobalExceptionHandler {
         return buildResponse(HttpStatus.CONFLICT, ex.getMessage());
     }
 
+    // US-20 / T-20.2: errores de validación devuelven un mapa {campo: mensaje}
+    // para que el cliente pueda mostrar cada error junto a su input.
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponseDTO> handleValidation(MethodArgumentNotValidException ex) {
-        String details = ex.getBindingResult().getFieldErrors().stream()
-                .map(FieldError::getDefaultMessage)
-                .collect(Collectors.joining(", "));
-        return buildResponse(HttpStatus.BAD_REQUEST, details);
+    public ResponseEntity<ValidationErrorResponseDTO> handleValidation(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError fe : ex.getBindingResult().getFieldErrors()) {
+            String mensaje = fe.getDefaultMessage() != null ? fe.getDefaultMessage() : "valor inválido";
+            errors.put(fe.getField(), mensaje);
+        }
+        ValidationErrorResponseDTO body = new ValidationErrorResponseDTO();
+        body.setTimestamp(LocalDateTime.now());
+        body.setStatus(HttpStatus.BAD_REQUEST.value());
+        body.setMessage("Error de validación");
+        body.setErrors(errors);
+        return ResponseEntity.badRequest().body(body);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponseDTO> handleGeneral(Exception ex) {
         return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
     }
-    
+
     private ResponseEntity<ErrorResponseDTO> buildResponse(HttpStatus status, String message) {
         ErrorResponseDTO error = new ErrorResponseDTO();
         error.setTimestamp(LocalDateTime.now());

--- a/src/test/java/com/ProyectoProcesosSoftware/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/ProyectoProcesosSoftware/exception/GlobalExceptionHandlerTest.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import com.ProyectoProcesosSoftware.dto.ValidationErrorResponseDTO;
 
 import java.util.List;
 
@@ -69,21 +70,25 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody().getStatus()).isEqualTo(409);
     }
 
-    @Test
-    @DisplayName("MethodArgumentNotValidException devuelve 400 con mensaje de campos")
+        @Test
+    @DisplayName("MethodArgumentNotValidException devuelve 400 con mapa de errores por campo")
     void handleValidation_devuelve400() {
         MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
         BindingResult bindingResult = mock(BindingResult.class);
-        FieldError fieldError = new FieldError("obj", "email", "El email es obligatorio");
+        FieldError emailError = new FieldError("obj", "email", "El email es obligatorio");
+        FieldError passError = new FieldError("obj", "password", "La contraseña debe tener al menos 6 caracteres");
 
         when(ex.getBindingResult()).thenReturn(bindingResult);
-        when(bindingResult.getFieldErrors()).thenReturn(List.of(fieldError));
+        when(bindingResult.getFieldErrors()).thenReturn(List.of(emailError, passError));
 
-        ResponseEntity<ErrorResponseDTO> response = handler.handleValidation(ex);
+        ResponseEntity<ValidationErrorResponseDTO> response = handler.handleValidation(ex);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(response.getBody().getMessage()).contains("El email es obligatorio");
         assertThat(response.getBody().getStatus()).isEqualTo(400);
+        assertThat(response.getBody().getMessage()).isEqualTo("Error de validación");
+        assertThat(response.getBody().getErrors())
+                .containsEntry("email", "El email es obligatorio")
+                .containsEntry("password", "La contraseña debe tener al menos 6 caracteres");
     }
 
     @Test


### PR DESCRIPTION
## Resumen

Antes, `handleValidation` concatenaba todos los mensajes de error en una sola cadena separada por comas, lo que impedía al cliente mostrar el error junto al input concreto. Ahora se devuelve un `ValidationErrorResponseDTO` con un `Map<String, String>` que asocia cada nombre de campo a su mensaje, manteniendo `timestamp`, `status` y un `message` genérico ("Error de validación").

## Tarea cubierta

- [x] T-20.2 · Mejorar `GlobalExceptionHandler` para devolver un mapa de errores por campo

## Archivos nuevos

- `src/main/java/com/ProyectoProcesosSoftware/dto/ValidationErrorResponseDTO.java`

## Archivos modificados

- `src/main/java/com/ProyectoProcesosSoftware/exception/GlobalExceptionHandler.java`
- `src/test/java/com/ProyectoProcesosSoftware/exception/GlobalExceptionHandlerTest.java`

## Verificación

```bash
./gradlew test jacocoTestCoverageVerification