### PR TITLE
docs(US-20): T-20.5 · Documentar el formato del error 400 en Swagger

### DIFF
--- a/src/main/java/com/ProyectoProcesosSoftware/controller/AuthController.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/controller/AuthController.java
@@ -10,6 +10,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 // ═══════════════════════════════════════════════════════════════
 // T-10 (Persona 4): Login endpoint
@@ -33,6 +36,8 @@ public class AuthController {
     private PasswordRecoveryService passwordRecoveryService;
 
     @PostMapping("/login")
+    @ApiResponse(responseCode = "400", description = "Datos de entrada inválidos",
+        content = @Content(schema = @Schema(implementation = ValidationErrorResponseDTO.class)))
     public ResponseEntity<?> login(@Valid @RequestBody LoginDTO dto) {
         Usuario usuario = usuarioRepository.findByEmail(dto.getEmail())
                 .orElse(null);
@@ -54,6 +59,8 @@ public class AuthController {
 
     // T-27 (Persona 6): Recuperación de contraseña
     @PostMapping("/forgot-password")
+    @ApiResponse(responseCode = "400", description = "Datos de entrada inválidos",
+        content = @Content(schema = @Schema(implementation = ValidationErrorResponseDTO.class)))
     public ResponseEntity<MessageResponseDTO> forgotPassword(@Valid @RequestBody ForgotPasswordDTO dto) {
         passwordRecoveryService.generarTokenRecuperacion(dto.getEmail());
         return ResponseEntity.ok(new MessageResponseDTO(
@@ -61,6 +68,8 @@ public class AuthController {
     }
 
     @PostMapping("/reset-password")
+    @ApiResponse(responseCode = "400", description = "Datos de entrada inválidos",
+        content = @Content(schema = @Schema(implementation = ValidationErrorResponseDTO.class)))
     public ResponseEntity<MessageResponseDTO> resetPassword(@Valid @RequestBody ResetPasswordDTO dto) {
         passwordRecoveryService.cambiarPassword(dto.getToken(), dto.getNuevaPassword());
         return ResponseEntity.ok(new MessageResponseDTO("Contraseña restablecida correctamente"));

--- a/src/main/java/com/ProyectoProcesosSoftware/controller/EventoController.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/controller/EventoController.java
@@ -10,6 +10,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 // ═══════════════════════════════════════════════════════════════
 // EventoController - Endpoints de eventos
@@ -25,6 +28,8 @@ public class EventoController {
     private EventoService eventoService;
 
     @PostMapping
+    @ApiResponse(responseCode = "400", description = "Datos de entrada inválidos",
+        content = @Content(schema = @Schema(implementation = ValidationErrorResponseDTO.class)))
     public ResponseEntity<EventoResponseDTO> crear(
             @Valid @RequestBody CrearEventoDTO dto, Authentication auth) {
         Long orgId = Long.parseLong(auth.getName());
@@ -50,6 +55,8 @@ public class EventoController {
     }
 
     @PutMapping("/{id}")
+    @ApiResponse(responseCode = "400", description = "Datos de entrada inválidos",
+        content = @Content(schema = @Schema(implementation = ValidationErrorResponseDTO.class)))
     public ResponseEntity<EventoResponseDTO> editar(
             @PathVariable Long id, @Valid @RequestBody EditarEventoDTO dto, Authentication auth) {
         Long orgId = Long.parseLong(auth.getName());

--- a/src/main/java/com/ProyectoProcesosSoftware/controller/UsuarioController.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/controller/UsuarioController.java
@@ -5,12 +5,16 @@ import com.ProyectoProcesosSoftware.dto.MessageResponseDTO;
 import com.ProyectoProcesosSoftware.dto.RegistroUsuarioDTO;
 import com.ProyectoProcesosSoftware.dto.UsuarioResponseDTO;
 import com.ProyectoProcesosSoftware.service.UsuarioService;
+import com.ProyectoProcesosSoftware.dto.ValidationErrorResponseDTO;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 @RestController
 @RequestMapping("/api/users")
@@ -20,6 +24,8 @@ public class UsuarioController {
     private UsuarioService usuarioService;
 
     @PostMapping
+    @ApiResponse(responseCode = "400", description = "Datos de entrada inválidos",
+        content = @Content(schema = @Schema(implementation = ValidationErrorResponseDTO.class)))
     public ResponseEntity<UsuarioResponseDTO> registrar(@Valid @RequestBody RegistroUsuarioDTO dto) {
         UsuarioResponseDTO response = usuarioService.registrar(dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -33,6 +39,8 @@ public class UsuarioController {
     }
 
     @PutMapping("/{id}")
+    @ApiResponse(responseCode = "400", description = "Datos de entrada inválidos",
+        content = @Content(schema = @Schema(implementation = ValidationErrorResponseDTO.class)))
     public ResponseEntity<UsuarioResponseDTO> editarPerfil(
             @PathVariable Long id,
             @Valid @RequestBody EditarUsuarioDTO dto,


### PR DESCRIPTION
## Resumen

Añade `@ApiResponse(responseCode = "400", ...)` apuntando a `ValidationErrorResponseDTO` en los endpoints POST/PUT de `AuthController` (login, forgot-password, reset-password), `UsuarioController` (registro, editar perfil) y `EventoController` (crear, editar). Swagger UI muestra ahora el esquema exacto del error 400 con el mapa de errores por campo.

## Tarea cubierta

- [x] T-20.5 · Documentar formato del error 400 en Swagger

## Archivos modificados

- `src/main/java/com/ProyectoProcesosSoftware/controller/AuthController.java`
- `src/main/java/com/ProyectoProcesosSoftware/controller/UsuarioController.java`
- `src/main/java/com/ProyectoProcesosSoftware/controller/EventoController.java`

## Verificación

```bash
./gradlew test integrationTest jacocoTestCoverageVerification