### PR TITLE
feat(US-28): panel de estadísticas para organizadores

### DIFF
--- a/src/main/java/com/ProyectoProcesosSoftware/controller/EstadisticasController.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/controller/EstadisticasController.java
@@ -1,0 +1,37 @@
+package com.ProyectoProcesosSoftware.controller;
+
+import com.ProyectoProcesosSoftware.dto.EstadisticasOrganizadorDTO;
+import com.ProyectoProcesosSoftware.service.EstadisticasService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@Tag(name = "Estadísticas", description = "Panel de métricas para organizadores")
+public class EstadisticasController {
+
+    @Autowired
+    private EstadisticasService estadisticasService;
+
+    @GetMapping("/me/stats")
+    @Operation(
+        summary = "Estadísticas del organizador autenticado",
+        description = "Devuelve numeroEventos, entradasVendidasTotales, ingresosTotales y porcentajeOcupacionMedia. Solo accesible por usuarios con rol ORGANIZADOR.")
+    @ApiResponse(responseCode = "200", description = "Estadísticas calculadas",
+            content = @Content(schema = @Schema(implementation = EstadisticasOrganizadorDTO.class)))
+    @ApiResponse(responseCode = "403", description = "El usuario no es ORGANIZADOR")
+    @ApiResponse(responseCode = "404", description = "Usuario no encontrado")
+    public ResponseEntity<EstadisticasOrganizadorDTO> miPanel(Authentication auth) {
+        Long userId = Long.parseLong(auth.getName());
+        return ResponseEntity.ok(estadisticasService.obtenerEstadisticasOrganizador(userId));
+    }
+}

--- a/src/main/java/com/ProyectoProcesosSoftware/dto/EstadisticasOrganizadorDTO.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/dto/EstadisticasOrganizadorDTO.java
@@ -1,0 +1,27 @@
+package com.ProyectoProcesosSoftware.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+/**
+ * US-28 / T-28.1: agregados básicos para el panel del organizador.
+ * Si el organizador no tiene eventos, todos los campos valen 0.
+ */
+@Data
+@Schema(description = "Estadísticas agregadas de un organizador")
+public class EstadisticasOrganizadorDTO {
+
+    @Schema(description = "Número total de eventos del organizador", example = "12")
+    private long numeroEventos;
+
+    @Schema(description = "Suma de entradas vendidas en todos sus eventos", example = "1850")
+    private long entradasVendidasTotales;
+
+    @Schema(description = "Ingresos totales (suma de precioFinal de tickets VALIDO)", example = "92450.50")
+    private BigDecimal ingresosTotales;
+
+    @Schema(description = "Porcentaje medio de ocupación (entradasVendidas / aforoMaximo)", example = "67.30")
+    private BigDecimal porcentajeOcupacionMedia;
+}

--- a/src/main/java/com/ProyectoProcesosSoftware/repository/EventoRepository.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/repository/EventoRepository.java
@@ -19,4 +19,9 @@ public interface EventoRepository extends JpaRepository<Evento, Long> {
             @Param("nombre") String nombre,
             @Param("ubicacion") String ubicacion,
             Pageable pageable);
+            
+// US-28 / T-28.2
+    java.util.List<com.ProyectoProcesosSoftware.model.Evento> findByOrganizadorId(Long organizadorId);
+
 }
+

--- a/src/main/java/com/ProyectoProcesosSoftware/repository/TicketRepository.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/repository/TicketRepository.java
@@ -17,4 +17,17 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
     boolean existsByEventoIdAndAsistenteIdAndEstado(
             Long eventoId, Long asistenteId, TicketStatus estado);
+
+            
+// US-28 / T-28.2: suma de precioFinal de tickets VALIDO del organizador.
+    @org.springframework.data.jpa.repository.Query(
+        "SELECT COALESCE(SUM(t.precioFinal), 0) " +
+        "FROM Ticket t " +
+        "WHERE t.evento.organizador.id = :organizadorId " +
+        "AND t.estado = com.ProyectoProcesosSoftware.model.TicketStatus.VALIDO")
+    java.math.BigDecimal sumarIngresosByOrganizadorId(
+            @org.springframework.data.repository.query.Param("organizadorId") Long organizadorId);
+
+
 }
+

--- a/src/main/java/com/ProyectoProcesosSoftware/service/EstadisticasService.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/service/EstadisticasService.java
@@ -1,0 +1,72 @@
+package com.ProyectoProcesosSoftware.service;
+
+import com.ProyectoProcesosSoftware.dto.EstadisticasOrganizadorDTO;
+import com.ProyectoProcesosSoftware.exception.ResourceNotFoundException;
+import com.ProyectoProcesosSoftware.exception.UnauthorizedActionException;
+import com.ProyectoProcesosSoftware.model.Evento;
+import com.ProyectoProcesosSoftware.model.Rol;
+import com.ProyectoProcesosSoftware.model.Usuario;
+import com.ProyectoProcesosSoftware.repository.EventoRepository;
+import com.ProyectoProcesosSoftware.repository.TicketRepository;
+import com.ProyectoProcesosSoftware.repository.UsuarioRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+/**
+ * US-28 / T-28.3: calcula los agregados del panel del organizador a partir
+ * de sus eventos y de los tickets VALIDO vendidos en ellos.
+ */
+@Service
+public class EstadisticasService {
+
+    @Autowired private EventoRepository eventoRepository;
+    @Autowired private TicketRepository ticketRepository;
+    @Autowired private UsuarioRepository usuarioRepository;
+
+    public EstadisticasOrganizadorDTO obtenerEstadisticasOrganizador(Long organizadorId) {
+        Usuario user = usuarioRepository.findById(organizadorId)
+                .orElseThrow(() -> new ResourceNotFoundException("Usuario no encontrado: " + organizadorId));
+        if (user.getRol() != Rol.ORGANIZADOR) {
+            throw new UnauthorizedActionException("Solo los organizadores tienen panel de estadísticas");
+        }
+
+        List<Evento> eventos = eventoRepository.findByOrganizadorId(organizadorId);
+        EstadisticasOrganizadorDTO dto = new EstadisticasOrganizadorDTO();
+
+        if (eventos.isEmpty()) {
+            dto.setNumeroEventos(0);
+            dto.setEntradasVendidasTotales(0);
+            dto.setIngresosTotales(BigDecimal.ZERO);
+            dto.setPorcentajeOcupacionMedia(BigDecimal.ZERO);
+            return dto;
+        }
+
+        long entradas = eventos.stream()
+                .mapToLong(e -> e.getEntradasVendidas() == null ? 0 : e.getEntradasVendidas())
+                .sum();
+
+        BigDecimal ingresos = ticketRepository.sumarIngresosByOrganizadorId(organizadorId);
+        if (ingresos == null) ingresos = BigDecimal.ZERO;
+
+        BigDecimal sumaPorcentajes = eventos.stream()
+                .filter(e -> e.getAforoMaximo() != null && e.getAforoMaximo() > 0)
+                .map(e -> BigDecimal.valueOf(e.getEntradasVendidas())
+                        .multiply(BigDecimal.valueOf(100))
+                        .divide(BigDecimal.valueOf(e.getAforoMaximo()), 4, RoundingMode.HALF_UP))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal ocupacionMedia = eventos.isEmpty()
+                ? BigDecimal.ZERO
+                : sumaPorcentajes.divide(BigDecimal.valueOf(eventos.size()), 2, RoundingMode.HALF_UP);
+
+        dto.setNumeroEventos(eventos.size());
+        dto.setEntradasVendidasTotales(entradas);
+        dto.setIngresosTotales(ingresos.setScale(2, RoundingMode.HALF_UP));
+        dto.setPorcentajeOcupacionMedia(ocupacionMedia);
+        return dto;
+    }
+}

--- a/src/test/java/com/ProyectoProcesosSoftware/service/EstadisticasServiceTest.java
+++ b/src/test/java/com/ProyectoProcesosSoftware/service/EstadisticasServiceTest.java
@@ -1,0 +1,111 @@
+package com.ProyectoProcesosSoftware.service;
+
+import com.ProyectoProcesosSoftware.dto.EstadisticasOrganizadorDTO;
+import com.ProyectoProcesosSoftware.exception.UnauthorizedActionException;
+import com.ProyectoProcesosSoftware.model.*;
+import com.ProyectoProcesosSoftware.repository.EventoRepository;
+import com.ProyectoProcesosSoftware.repository.TicketRepository;
+import com.ProyectoProcesosSoftware.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EstadisticasServiceTest {
+
+    @Mock private EventoRepository eventoRepository;
+    @Mock private TicketRepository ticketRepository;
+    @Mock private UsuarioRepository usuarioRepository;
+    @InjectMocks private EstadisticasService service;
+
+    private Usuario organizador;
+
+    @BeforeEach
+    void setUp() {
+        organizador = new Usuario();
+        organizador.setId(1L);
+        organizador.setRol(Rol.ORGANIZADOR);
+    }
+
+    @Test
+    @DisplayName("organizador_sinEventos_devuelveCeros")
+    void organizador_sinEventos_devuelveCeros() {
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(organizador));
+        when(eventoRepository.findByOrganizadorId(1L)).thenReturn(Collections.emptyList());
+
+        EstadisticasOrganizadorDTO dto = service.obtenerEstadisticasOrganizador(1L);
+
+        assertThat(dto.getNumeroEventos()).isZero();
+        assertThat(dto.getEntradasVendidasTotales()).isZero();
+        assertThat(dto.getIngresosTotales()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(dto.getPorcentajeOcupacionMedia()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("organizador_conEventosSinVentas_ingresosCero")
+    void organizador_conEventosSinVentas_ingresosCero() {
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(organizador));
+        Evento e = nuevoEvento(100, 0);
+        when(eventoRepository.findByOrganizadorId(1L)).thenReturn(List.of(e));
+        when(ticketRepository.sumarIngresosByOrganizadorId(1L)).thenReturn(BigDecimal.ZERO);
+
+        EstadisticasOrganizadorDTO dto = service.obtenerEstadisticasOrganizador(1L);
+
+        assertThat(dto.getNumeroEventos()).isEqualTo(1);
+        assertThat(dto.getEntradasVendidasTotales()).isZero();
+        assertThat(dto.getIngresosTotales()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(dto.getPorcentajeOcupacionMedia()).isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    @DisplayName("organizador_conVentas_calculaCorrectamente")
+    void organizador_conVentas_calculaCorrectamente() {
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(organizador));
+        // Evento 1: 100 aforo, 50 vendidas (50%). Evento 2: 200 aforo, 100 vendidas (50%).
+        when(eventoRepository.findByOrganizadorId(1L)).thenReturn(List.of(
+                nuevoEvento(100, 50),
+                nuevoEvento(200, 100)
+        ));
+        when(ticketRepository.sumarIngresosByOrganizadorId(1L))
+                .thenReturn(new BigDecimal("7500.00"));
+
+        EstadisticasOrganizadorDTO dto = service.obtenerEstadisticasOrganizador(1L);
+
+        assertThat(dto.getNumeroEventos()).isEqualTo(2);
+        assertThat(dto.getEntradasVendidasTotales()).isEqualTo(150);
+        assertThat(dto.getIngresosTotales()).isEqualByComparingTo("7500.00");
+        assertThat(dto.getPorcentajeOcupacionMedia()).isEqualByComparingTo("50.00");
+    }
+
+    @Test
+    @DisplayName("usuario_noOrganizador_lanza403")
+    void usuario_noOrganizador_lanza403() {
+        organizador.setRol(Rol.ASISTENTE);
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(organizador));
+
+        assertThatThrownBy(() -> service.obtenerEstadisticasOrganizador(1L))
+                .isInstanceOf(UnauthorizedActionException.class)
+                .hasMessageContaining("organizadores");
+    }
+
+    private Evento nuevoEvento(int aforo, int vendidas) {
+        Evento e = new Evento();
+        e.setAforoMaximo(aforo);
+        e.setEntradasVendidas(vendidas);
+        e.setOrganizador(organizador);
+        return e;
+    }
+}


### PR DESCRIPTION
Añade EstadisticasOrganizadorDTO (numeroEventos, entradasVendidasTotales, ingresosTotales, porcentajeOcupacionMedia), EstadisticasService que calcula los agregados a partir de los eventos del organizador y los tickets VALIDO, EstadisticasController con GET /api/users/me/stats restringido a rol ORGANIZADOR, queries nuevas en EventoRepository y TicketRepository, anotaciones Swagger y tests unitarios cubriendo sin eventos, sin ventas, con ventas y acceso no autorizado (T-28.1 a T-28.5 + T-28.7).