### PR TITLE
T-21.1 fix flujo asistente: error de sintaxis JS y div page-stats duplicado

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -493,16 +493,6 @@
     </div>
   </div>
 
- <!-- STATS (US-28, solo ORGANIZADOR) -->
-  <div class="page" id="page-stats">
-    <div class="page-header">
-      <h2>Mis estadísticas</h2>
-    </div>
-    <div id="stats-content">
-      <div class="loader-wrap"><div class="spinner"></div></div>
-    </div>
-  </div>
-
 </div>
 
 <!-- ══════════════ MODALS ══════════════ -->
@@ -706,7 +696,6 @@ function showPage(name) {
   if (name === 'stats') loadStats();
   if (name === 'favorites') loadFavorites();
   if (name === 'profile') loadProfile();
-  if (name === 'stats') loadStats();
 }
 
 /* ═══════ API CALLS ═══════ */
@@ -875,11 +864,8 @@ async function openDetail(id) {
                   && currentUser.rol === 'ORGANIZADOR'
                   && currentUser.id === e.organizadorId;
     if (esDueño) {
-      actions += <button class="btn btn-sm" onclick="openEditEvent(${e.id})">Editar</button>;
-      // US-22 / T-22.3: el botón "Eliminar" se ofrece siempre. Si el evento
-      // tiene tickets vendidos, el backend responde 409 y mostramos el mensaje
-      // claro al usuario (gestionado en doDeleteEvent).
-      actions += <button class="btn btn-danger btn-sm" onclick="doDeleteEvent(${e.id})">Eliminar</button>;
+      actions += `<button class="btn btn-sm" onclick="openEditEvent(${e.id})">Editar</button>`;
+      actions += `<button class="btn btn-danger btn-sm" onclick="doDeleteEvent(${e.id})">Eliminar</button>`;
     } else if (currentUser && currentUser.rol === 'ASISTENTE' && e.estado === 'PUBLICADO' && e.plazasDisponibles > 0) {
       actions += `<div id="dm-purchase-area"><button class="btn btn-accent" id="buy-btn" onclick="doComprarEntrada(${e.id})">Comprar Entrada — €${parseFloat(e.precioActual || e.precioBase).toFixed(2)}</button></div>`;
     } else if (currentUser && currentUser.rol === 'ASISTENTE' && e.estado === 'AGOTADO') {
@@ -894,8 +880,9 @@ async function openDetail(id) {
     el('dm-reviews-section').style.display = 'block';
     loadReviews(id, 0);
     loadReviewForm(id);
-  } catch(e) {
-    el('dm-title').textContent = 'Error al cargar';
+  } catch(err) {
+    el('dm-title').textContent = 'No se pudo cargar el evento';
+    el('dm-status').innerHTML = `<div class="alert alert-err">${err.message}</div>`;
   }
 }
 


### PR DESCRIPTION
  Revisión funcional del flujo asistente. Encontré que la PR anterior dejó dos template literals sin backticks en openDetail, lo que rompía todo el JS de la página (la consola tiraba SyntaxError al cargar y no se
  podía iniciar sesión ni listar eventos).
  
  Cambios:
  - Arreglo los dos template literals de los botones Editar/Eliminar en openDetail.
  - Quito el segundo <div id="page-stats"> duplicado (HTML inválido, dos elementos con el mismo id).
  - Quito la llamada doble a loadStats() en el router.
  - Mejoro el catch de openDetail para mostrar el mensaje real en lugar de un genérico "Error al cargar".