### PR TITLE
T-31.5/T-31.6/T-31.8: seeder demo, datos de reseñas/favoritos y perfil en docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       DB_PASSWORD: root
       JWT_SECRET: eventpass-prod-secret-key-que-debe-tener-al-menos-256-bits-segura-1234567890
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/eventpass?createDatabaseIfNotExist=true&useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+      # Descomenta para arrancar con datos demo precargados (perfil "demo")
+      # SPRING_PROFILES_ACTIVE: demo
     depends_on:
       mysql:
         condition: service_healthy

--- a/src/main/java/com/ProyectoProcesosSoftware/config/DataSeederConfig.java
+++ b/src/main/java/com/ProyectoProcesosSoftware/config/DataSeederConfig.java
@@ -1,0 +1,124 @@
+package com.ProyectoProcesosSoftware.config;
+
+import com.ProyectoProcesosSoftware.model.*;
+import com.ProyectoProcesosSoftware.repository.*;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Seeder Java alternativo al SQL puro, usado únicamente con perfil "demo".
+ * Solo siembra si la BD está vacía (idempotente).
+ */
+@Configuration
+@Profile("demo")
+public class DataSeederConfig {
+
+    @Bean
+    CommandLineRunner seed(UsuarioRepository usuarios,
+                           EventoRepository eventos,
+                           TicketRepository tickets,
+                           ResenaRepository resenas,
+                           FavoritoRepository favoritos,
+                           PasswordEncoder encoder) {
+        return args -> {
+            if (usuarios.count() > 0) return; // ya sembrado
+
+            // ── Usuarios ──
+            Usuario org   = nuevoUsuario("Olivia Organizadora", "org@demo.com",   "Demo1234!", Rol.ORGANIZADOR, encoder);
+            Usuario alice = nuevoUsuario("Alice Asistente",     "alice@demo.com", "Demo1234!", Rol.ASISTENTE,   encoder);
+            Usuario bob   = nuevoUsuario("Bob Asistente",       "bob@demo.com",   "Demo1234!", Rol.ASISTENTE,   encoder);
+            Usuario carol = nuevoUsuario("Carol Asistente",     "carol@demo.com", "Demo1234!", Rol.ASISTENTE,   encoder);
+            usuarios.saveAll(List.of(org, alice, bob, carol));
+
+            // ── Eventos ──
+            Evento e1 = nuevoEvento("Concierto Jazz Bilbao",  "EarlyBird 0% de ocupación.",   LocalDate.now().plusMonths(2), LocalTime.of(20,0), "Bilbao",        100, 0,  50.00, EstadoEvento.PUBLICADO, org);
+            Evento e2 = nuevoEvento("Festival Indie Donosti", "Regular 60% de ocupación.",    LocalDate.now().plusMonths(2), LocalTime.of(21,0), "San Sebastián", 100, 60, 80.00, EstadoEvento.PUBLICADO, org);
+            Evento e3 = nuevoEvento("Show Stand-Up Vitoria",  "LastMinute 90% de ocupación.", LocalDate.now().plusMonths(1), LocalTime.of(22,0), "Vitoria",       100, 90, 30.00, EstadoEvento.PUBLICADO, org);
+            Evento e4 = nuevoEvento("Final Liga Esports",     "AGOTADO 100% de ocupación.",   LocalDate.now().plusMonths(3), LocalTime.of(19,0), "Bilbao Arena",   50, 50, 25.00, EstadoEvento.AGOTADO,   org);
+            Evento e5 = nuevoEvento("Charla Tech (Borrador)", "Aún sin publicar (BORRADOR).", LocalDate.now().plusMonths(6), LocalTime.of(18,0), "Bilbao",        200, 0,   0.00, EstadoEvento.BORRADOR,  org);
+            eventos.saveAll(List.of(e1, e2, e3, e4, e5));
+
+            // ── Tickets ──
+            tickets.saveAll(List.of(
+                nuevoTicket(e1, alice, EstadoTicket.VALIDO,    50.00),
+                nuevoTicket(e2, alice, EstadoTicket.VALIDO,    80.00),
+                nuevoTicket(e3, bob,   EstadoTicket.VALIDO,    45.00),
+                nuevoTicket(e2, carol, EstadoTicket.CANCELADO, 80.00)
+            ));
+
+            // ── Reseñas (US-26) ──
+            resenas.saveAll(List.of(
+                nuevaResena(e1, alice, 5, "Concierto espectacular, ambiente increíble."),
+                nuevaResena(e2, alice, 4, "Muy buen festival aunque algo concurrido."),
+                nuevaResena(e3, bob,   3, "Stand-up entretenido, esperaba un poco más.")
+            ));
+
+            // ── Favoritos (US-27): 2 por asistente ──
+            favoritos.saveAll(List.of(
+                nuevoFavorito(alice, e1), nuevoFavorito(alice, e3),
+                nuevoFavorito(bob,   e2), nuevoFavorito(bob,   e4),
+                nuevoFavorito(carol, e1), nuevoFavorito(carol, e2)
+            ));
+        };
+    }
+
+    private static Usuario nuevoUsuario(String nombre, String email, String pass, Rol rol, PasswordEncoder enc) {
+        Usuario u = new Usuario();
+        u.setNombre(nombre);
+        u.setEmail(email);
+        u.setPassword(enc.encode(pass));
+        u.setRol(rol);
+        return u;
+    }
+
+    private static Evento nuevoEvento(String nombre, String desc, LocalDate fecha, LocalTime hora,
+                                      String ubic, int aforo, int vendidas, double precio,
+                                      EstadoEvento estado, Usuario organizador) {
+        Evento e = new Evento();
+        e.setNombre(nombre);
+        e.setDescripcion(desc);
+        e.setFecha(fecha);
+        e.setHora(hora);
+        e.setUbicacion(ubic);
+        e.setAforoMaximo(aforo);
+        e.setEntradasVendidas(vendidas);
+        e.setPrecioBase(java.math.BigDecimal.valueOf(precio));
+        e.setEstado(estado);
+        e.setOrganizador(organizador);
+        return e;
+    }
+
+    private static Ticket nuevoTicket(Evento e, Usuario u, EstadoTicket estado, double precio) {
+        Ticket t = new Ticket();
+        t.setUuid(UUID.randomUUID().toString());
+        t.setEvento(e);
+        t.setAsistente(u);
+        t.setEstado(estado);
+        t.setPrecioFinal(java.math.BigDecimal.valueOf(precio));
+        return t;
+    }
+
+    private static Resena nuevaResena(Evento e, Usuario u, int puntos, String comentario) {
+        Resena r = new Resena();
+        r.setEvento(e);
+        r.setAsistente(u);
+        r.setPuntuacion(puntos);
+        r.setComentario(comentario);
+        return r;
+    }
+
+    private static Favorito nuevoFavorito(Usuario u, Evento e) {
+        Favorito f = new Favorito();
+        f.setUsuario(u);
+        f.setEvento(e);
+        return f;
+    }
+}

--- a/src/main/resources/data-demo.sql
+++ b/src/main/resources/data-demo.sql
@@ -16,3 +16,16 @@ INSERT INTO tickets (id, uuid, evento_id, asistente_id, estado, precio_final, fe
   (3002, '22222222-2222-2222-2222-222222222222', 2002, 1002, 'VALIDO',    80.00, CURRENT_TIMESTAMP),
   (3003, '33333333-3333-3333-3333-333333333333', 2003, 1003, 'VALIDO',    45.00, CURRENT_TIMESTAMP),
   (3004, '44444444-4444-4444-4444-444444444444', 2002, 1004, 'CANCELADO', 80.00, CURRENT_TIMESTAMP);
+
+  INSERT INTO resenas (id, evento_id, asistente_id, puntuacion, comentario, fecha_creacion) VALUES
+  (4001, 2001, 1002, 5, 'Concierto espectacular, ambiente increíble.',           CURRENT_TIMESTAMP),
+  (4002, 2002, 1002, 4, 'Muy buen festival aunque algo concurrido.',             CURRENT_TIMESTAMP),
+  (4003, 2003, 1003, 3, 'Stand-up entretenido, esperaba un poco más de chistes.',CURRENT_TIMESTAMP);
+
+INSERT INTO favoritos (id, usuario_id, evento_id, fecha_alta) VALUES
+  (5001, 1002, 2001, CURRENT_TIMESTAMP),
+  (5002, 1002, 2003, CURRENT_TIMESTAMP),
+  (5003, 1003, 2002, CURRENT_TIMESTAMP),
+  (5004, 1003, 2004, CURRENT_TIMESTAMP),
+  (5005, 1004, 2001, CURRENT_TIMESTAMP),
+  (5006, 1004, 2002, CURRENT_TIMESTAMP);


### PR DESCRIPTION
## Resumen
Completa las tres tareas pendientes de la US-31 (datos demo):

- **T-31.5** — `DataSeederConfig` con `@Profile("demo")` como alternativa Java al SQL puro.
- **T-31.6** — Datos demo para reseñas (US-26) y favoritos (US-27).
- **T-31.8** — Variable `SPRING_PROFILES_ACTIVE=demo` en `docker-compose.yml` (comentada, lista para descomentar).

## Cambios

### `src/main/resources/data-demo.sql`
- Añadidas **3 reseñas** sobre los eventos publicados, una por cada asistente con ticket válido (puntuaciones 5/4/3).
- Añadidos **6 favoritos**, 2 por cada uno de los 3 asistentes demo, repartidos entre los eventos publicados y el agotado.

No hace falta actualizar la tabla `eventos`: la media y el contador de reseñas se calculan en `EventoMapper`, no se persisten.

### `src/main/java/com/ProyectoProcesosSoftware/config/DataSeederConfig.java` (nuevo)
- Seeder Java condicionado a `@Profile("demo")` que reproduce el mismo dataset usando los repositorios JPA y `PasswordEncoder`.
- Idempotente: comprueba que la BD está vacía (`usuarios.count() == 0`) antes de insertar.
- Sirve como alternativa al SQL puro si más adelante se ejecuta el perfil `demo` sobre MySQL y aparecen incompatibilidades de dialecto.

### `docker-compose.yml`
- Añadida línea comentada `# SPRING_PROFILES_ACTIVE: demo` en el bloque `app.environment`, junto a un breve comentario explicativo.

## Cómo probarlo

**En local con Gradle:**
```bash
./gradlew bootRun --args='--spring.profiles.active=demo'