### PR TITLE
T-31.8 · Variable SPRING_PROFILES_ACTIVE=demo en docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     ports:
       - "8080:8080"
     environment:
+      # Descomenta para arrancar con datos de demo precargados:
+      # SPRING_PROFILES_ACTIVE: demo
       DB_USERNAME: root
       DB_PASSWORD: root
       JWT_SECRET: eventpass-prod-secret-key-que-debe-tener-al-menos-256-bits-segura-1234567890


### PR DESCRIPTION
Se añade una línea comentada en el docker-compose.yml dentro del bloque environment del servicio app para facilitar el arranque con datos de demo cuando se usa Docker.
Para activarla, el evaluador solo tiene que descomentar esta línea:

yaml
#SPRING_PROFILES_ACTIVE: demo

Y arrancar con:
cmd
docker-compose up --build

Esto carga automáticamente los 4 usuarios, 5 eventos y 4 tickets definidos en data-demo.sql.
Closes #211